### PR TITLE
Solus: add unoconv installation

### DIFF
--- a/distro/Solus/post_install_solus.sh
+++ b/distro/Solus/post_install_solus.sh
@@ -156,10 +156,24 @@ install_Sublime_Text() {
     after_install "Sublime Text"
 }
 
+install_Unoconv() {
+    banner "Installing unoconv"
+    
+    show_info "This scripts needs libreoffice"
+    
+    mkdir -p ~/LEO/unoconv
+    git clone https://github.com/dagwieers/unoconv.git ~/LEO/unoconv
+    sudo ln -s ~/LEO/unoconv/unoconv /usr/bin/unoconv
+    
+    after_install "unoconv"
+}
+
+
 install_Everything() {
     install_Neofetch
     install_Zoom_Client
     install_Xclip
     install_Xkill
+    install_Unoconv
     install_Sublime_Text
 }


### PR DESCRIPTION
- Added **unoconv** installation
- Saves setup in `~/LEO/`
- Creating symbolic link with binary file to `/usr/bin/`